### PR TITLE
Fixed, -lcurl -lssl -lcrypto missing while make. and generalize PATH for EeasyBuild

### DIFF
--- a/makefile
+++ b/makefile
@@ -2,13 +2,13 @@
 CXX=g++ -std=c++11
 
 #HTSLIB LIBRARY [SPECIFY YOUR OWN PATHS]
-HTSLIB_INC=$(HOME)/Tools/htslib-1.9
-HTSLIB_LIB=$(HOME)/Tools/htslib-1.9/libhts.a
+HTSLIB_INC=$(EBROOTHTSLIB)/include/htslib
+HTSLIB_LIB=$(EBROOTHTSLIB)/lib/libhts.a
 
 #BOOST IOSTREAM & PROGRAM_OPTION LIBRARIES [SPECIFY YOUR OWN PATHS]
-BOOST_INC=/usr/include
-BOOST_LIB_IO=/usr/lib/x86_64-linux-gnu/libboost_iostreams.a
-BOOST_LIB_PO=/usr/lib/x86_64-linux-gnu/libboost_program_options.a
+BOOST_INC=$(EBROOTBOOST)/include/boost
+BOOST_LIB_IO=$(EBROOTBOOST)/lib/libboost_iostreams.a
+BOOST_LIB_PO=$(EBROOTBOOST)/lib/libboost_program_options.a
 
 #HTSLIB LIBRARY [SPECIFY YOUR OWN PATHS]
 #HTSLIB_INC=/software/UHTS/Analysis/samtools/1.4/include
@@ -33,7 +33,7 @@ CXXFLAG=-O3 -mavx2 -mfma
 LDFLAG=-O3
 
 #DYNAMIC LIBRARIES
-DYN_LIBS=-lz -lbz2 -lm -lpthread -llzma
+DYN_LIBS=-lz -lbz2 -lm -lpthread -llzma -lcurl -lssl -lcrypto
 
 #SHAPEIT SOURCES & BINARY
 BFILE=bin/shapeit4


### PR DESCRIPTION

Hi, Here are some fixes that let me be able to build **shapeit4** as **easybuild config** without errors.
As I've try to build **shapeit4** on my organization HPC and also willing to encode build process as easybuild-config one, so that I can contribute back something to **EB** community.
I started with load modules dependencies needed.
```
 ml load foss/2018b 
 ml load HTSlib/1.9-foss-2018b 
 ml load Boost/1.67.0-foss-2018b
```
Then, I've modified your `makefile` to look something like this.
```
#HTSLIB LIBRARY [SPECIFY YOUR OWN PATHS]
HTSLIB_INC=$(EBROOTHTSLIB)/include/htslib
HTSLIB_LIB=$(EBROOTHTSLIB)/lib/libhts.a

#BOOST IOSTREAM & PROGRAM_OPTION LIBRARIES [SPECIFY YOUR OWN PATHS]
BOOST_INC=$(EBROOTBOOST)/include/boost
BOOST_LIB_IO=$(EBROOTBOOST)/lib/libboost_iostreams.a
BOOST_LIB_PO=$(EBROOTBOOST)/lib/libboost_program_options.a
```
which will be compatible with easybuild & modules on any HPC environment 
and the compilation went well except when they try to load dynamic libs, I encounter this error.
```
(base) [kphornsi@tara-frontend-1 shapeit4]$ make
g++ -std=c++11 -O3 obj/main.o obj/haplotype_segment.o obj/compute_job.o obj/variant.o obj/hmm_parameters.o obj/genotype_mask.o obj/genotype_sweep.o obj/genotype_prune.o obj/genotype_managment.o obj/genotype_build.o obj/genotype_reader1.o obj/gmap_reader.o obj/genotype_reader2.o obj/haplotype_writer.o obj/variant_map.o obj/genotype_set.o obj/haplotype_set.o obj/pbwt_solver.o obj/builder.o obj/phaser_initialise.o obj/phaser_finalise.o obj/phaser_management.o obj/phaser_parameters.o obj/phaser_algorithm.o /tarafs/biobank/data/modules/.local/easybuild/software/HTSlib/1.9-foss-2018b/lib/libhts.a /tarafs/biobank/data/modules/.local/easybuild/software/Boost/1.67.0-foss-2018b/lib/libboost_iostreams.a /tarafs/biobank/data/modules/.local/easybuild/software/Boost/1.67.0-foss-2018b/lib/libboost_program_options.a -o bin/shapeit4 -lz -lbz2 -lm -lpthread -llzma
/tarafs/biobank/data/modules/.local/easybuild/software/HTSlib/1.9-foss-2018b/lib/libhts.a(hfile_libcurl.o):hfile_libcurl.c:function easy_errno: error: undefined reference to 'curl_easy_getinfo'
/tarafs/biobank/data/modules/.local/easybuild/software/HTSlib/1.9-foss-2018b/lib/libhts.a(hfile_libcurl.o):hfile_libcurl.c:function easy_errno: error: undefined reference to 'curl_easy_getinfo'
/tarafs/biobank/data/modules/.local/easybuild/software/HTSlib/1.9-foss-2018b/lib/libhts.a(hfile_libcurl.o):hfile_libcurl.c:function wait_perform: error: undefined reference to 'curl_multi_fdset'
/tarafs/biobank/data/modules/.local/easybuild/software/HTSlib/1.9-foss-2018b/lib/libhts.a(hfile_libcurl.o):hfile_libcurl.c:function wait_perform: error: undefined reference to 'curl_multi_perform'
/tarafs/biobank/data/modules/.local/easybuild/software/HTSlib/1.9-foss-2018b/lib/libhts.a(hfile_libcurl.o):hfile_libcurl.c:function wait_perform: error: undefined reference to 'curl_multi_info_read'
/tarafs/biobank/data/modules/.local/easybuild/software/HTSlib/1.9-foss-2018b/lib/libhts.a(hfile_libcurl.o):hfile_libcurl.c:function wait_perform: error: undefined reference to 'curl_multi_timeout'
/tarafs/biobank/data/modules/.local/easybuild/software/HTSlib/1.9-foss-2018b/lib/libhts.a(hfile_libcurl.o):hfile_libcurl.c:function libcurl_close: error: undefined reference to 'curl_easy_pause'
/tarafs/biobank/data/modules/.local/easybuild/software/HTSlib/1.9-foss-2018b/lib/libhts.a(hfile_libcurl.o):hfile_libcurl.c:function libcurl_close: error: undefined reference to 'curl_multi_remove_handle'
/tarafs/biobank/data/modules/.local/easybuild/software/HTSlib/1.9-foss-2018b/lib/libhts.a(hfile_libcurl.o):hfile_libcurl.c:function libcurl_close: error: undefined reference to 'curl_easy_cleanup'
/tarafs/biobank/data/modules/.local/easybuild/software/HTSlib/1.9-foss-2018b/lib/libhts.a(hfile_libcurl.o):hfile_libcurl.c:function libcurl_close: error: undefined reference to 'curl_multi_cleanup'
/tarafs/biobank/data/modules/.local/easybuild/software/HTSlib/1.9-foss-2018b/lib/libhts.a(hfile_libcurl.o):hfile_libcurl.c:function libcurl_close: error: undefined reference to 'curl_multi_remove_handle'
/tarafs/biobank/data/modules/.local/easybuild/software/HTSlib/1.9-foss-2018b/lib/libhts.a(hfile_libcurl.o):hfile_libcurl.c:function libcurl_write: error: undefined reference to 'curl_easy_pause'
/tarafs/biobank/data/modules/.local/easybuild/software/HTSlib/1.9-foss-2018b/lib/libhts.a(hfile_libcurl.o):hfile_libcurl.c:function libcurl_exit: error: undefined reference to 'curl_share_cleanup'
/tarafs/biobank/data/modules/.local/easybuild/software/HTSlib/1.9-foss-2018b/lib/libhts.a(hfile_libcurl.o):hfile_libcurl.c:function libcurl_open: error: undefined reference to 'curl_multi_init'
/tarafs/biobank/data/modules/.local/easybuild/software/HTSlib/1.9-foss-2018b/lib/libhts.a(hfile_libcurl.o):hfile_libcurl.c:function libcurl_open: error: undefined reference to 'curl_easy_init'
/tarafs/biobank/data/modules/.local/easybuild/software/HTSlib/1.9-foss-2018b/lib/libhts.a(hfile_libcurl.o):hfile_libcurl.c:function libcurl_open: error: undefined reference to 'curl_easy_setopt'
/tarafs/biobank/data/modules/.local/easybuild/software/HTSlib/1.9-foss-2018b/lib/libhts.a(hfile_libcurl.o):hfile_libcurl.c:function libcurl_open: error: undefined reference to 'curl_easy_setopt'
/tarafs/biobank/data/modules/.local/easybuild/software/HTSlib/1.9-foss-2018b/lib/libhts.a(hfile_libcurl.o):hfile_libcurl.c:function libcurl_open: error: undefined reference to 'curl_easy_setopt'
/tarafs/biobank/data/modules/.local/easybuild/software/HTSlib/1.9-foss-2018b/lib/libhts.a(hfile_libcurl.o):hfile_libcurl.c:function libcurl_open: error: undefined reference to 'curl_easy_setopt'
/tarafs/biobank/data/modules/.local/easybuild/software/HTSlib/1.9-foss-2018b/lib/libhts.a(hfile_libcurl.o):hfile_libcurl.c:function libcurl_open: error: undefined reference to 'curl_multi_add_handle'
/tarafs/biobank/data/modules/.local/easybuild/software/HTSlib/1.9-foss-2018b/lib/libhts.a(hfile_libcurl.o):hfile_libcurl.c:function libcurl_open: error: undefined reference to 'curl_multi_remove_handle'
/tarafs/biobank/data/modules/.local/easybuild/software/HTSlib/1.9-foss-2018b/lib/libhts.a(hfile_libcurl.o):hfile_libcurl.c:function libcurl_open: error: undefined reference to 'curl_easy_cleanup'
/tarafs/biobank/data/modules/.local/easybuild/software/HTSlib/1.9-foss-2018b/lib/libhts.a(hfile_libcurl.o):hfile_libcurl.c:function libcurl_open: error: undefined reference to 'curl_multi_cleanup'
/tarafs/biobank/data/modules/.local/easybuild/software/HTSlib/1.9-foss-2018b/lib/libhts.a(hfile_libcurl.o):hfile_libcurl.c:function libcurl_open: error: undefined reference to 'curl_easy_getinfo'
/tarafs/biobank/data/modules/.local/easybuild/software/HTSlib/1.9-foss-2018b/lib/libhts.a(hfile_libcurl.o):hfile_libcurl.c:function restart_from_position: error: undefined reference to 'curl_easy_duphandle'
/tarafs/biobank/data/modules/.local/easybuild/software/HTSlib/1.9-foss-2018b/lib/libhts.a(hfile_libcurl.o):hfile_libcurl.c:function restart_from_position: error: undefined reference to 'curl_easy_cleanup'
/tarafs/biobank/data/modules/.local/easybuild/software/HTSlib/1.9-foss-2018b/lib/libhts.a(hfile_libcurl.o):hfile_libcurl.c:function restart_from_position: error: undefined reference to 'curl_easy_pause'
/tarafs/biobank/data/modules/.local/easybuild/software/HTSlib/1.9-foss-2018b/lib/libhts.a(hfile_libcurl.o):hfile_libcurl.c:function restart_from_position: error: undefined reference to 'curl_multi_remove_handle'
/tarafs/biobank/data/modules/.local/easybuild/software/HTSlib/1.9-foss-2018b/lib/libhts.a(hfile_libcurl.o):hfile_libcurl.c:function restart_from_position: error: undefined reference to 'curl_easy_reset'
/tarafs/biobank/data/modules/.local/easybuild/software/HTSlib/1.9-foss-2018b/lib/libhts.a(hfile_libcurl.o):hfile_libcurl.c:function restart_from_position: error: undefined reference to 'curl_multi_add_handle'
/tarafs/biobank/data/modules/.local/easybuild/software/HTSlib/1.9-foss-2018b/lib/libhts.a(hfile_libcurl.o):hfile_libcurl.c:function restart_from_position: error: undefined reference to 'curl_easy_cleanup'
/tarafs/biobank/data/modules/.local/easybuild/software/HTSlib/1.9-foss-2018b/lib/libhts.a(hfile_libcurl.o):hfile_libcurl.c:function restart_from_position: error: undefined reference to 'curl_easy_reset'
/tarafs/biobank/data/modules/.local/easybuild/software/HTSlib/1.9-foss-2018b/lib/libhts.a(hfile_libcurl.o):hfile_libcurl.c:function restart_from_position: error: undefined reference to 'curl_easy_reset'
/tarafs/biobank/data/modules/.local/easybuild/software/HTSlib/1.9-foss-2018b/lib/libhts.a(hfile_libcurl.o):hfile_libcurl.c:function libcurl_read: error: undefined reference to 'curl_easy_pause'
/tarafs/biobank/data/modules/.local/easybuild/software/HTSlib/1.9-foss-2018b/lib/libhts.a(hfile_libcurl.o):hfile_libcurl.c:function hfile_plugin_init_libcurl: error: undefined reference to 'curl_global_init'
/tarafs/biobank/data/modules/.local/easybuild/software/HTSlib/1.9-foss-2018b/lib/libhts.a(hfile_libcurl.o):hfile_libcurl.c:function hfile_plugin_init_libcurl: error: undefined reference to 'curl_share_init'
/tarafs/biobank/data/modules/.local/easybuild/software/HTSlib/1.9-foss-2018b/lib/libhts.a(hfile_libcurl.o):hfile_libcurl.c:function hfile_plugin_init_libcurl: error: undefined reference to 'curl_share_setopt'
/tarafs/biobank/data/modules/.local/easybuild/software/HTSlib/1.9-foss-2018b/lib/libhts.a(hfile_libcurl.o):hfile_libcurl.c:function hfile_plugin_init_libcurl: error: undefined reference to 'curl_share_setopt'
/tarafs/biobank/data/modules/.local/easybuild/software/HTSlib/1.9-foss-2018b/lib/libhts.a(hfile_libcurl.o):hfile_libcurl.c:function hfile_plugin_init_libcurl: error: undefined reference to 'curl_share_setopt'
/tarafs/biobank/data/modules/.local/easybuild/software/HTSlib/1.9-foss-2018b/lib/libhts.a(hfile_libcurl.o):hfile_libcurl.c:function hfile_plugin_init_libcurl: error: undefined reference to 'curl_version_info'
/tarafs/biobank/data/modules/.local/easybuild/software/HTSlib/1.9-foss-2018b/lib/libhts.a(hfile_libcurl.o):hfile_libcurl.c:function hfile_plugin_init_libcurl: error: undefined reference to 'curl_share_cleanup'
/tarafs/biobank/data/modules/.local/easybuild/software/HTSlib/1.9-foss-2018b/lib/libhts.a(hfile_libcurl.o):hfile_libcurl.c:function hfile_plugin_init_libcurl: error: undefined reference to 'curl_global_cleanup'
/tarafs/biobank/data/modules/.local/easybuild/software/HTSlib/1.9-foss-2018b/lib/libhts.a(hfile_libcurl.o):hfile_libcurl.c:function hfile_plugin_init_libcurl: error: undefined reference to 'curl_share_cleanup'
/tarafs/biobank/data/modules/.local/easybuild/software/HTSlib/1.9-foss-2018b/lib/libhts.a(hfile_libcurl.o):hfile_libcurl.c:function hfile_plugin_init_libcurl: error: undefined reference to 'curl_global_cleanup'
/tarafs/biobank/data/modules/.local/easybuild/software/HTSlib/1.9-foss-2018b/lib/libhts.a(hfile_libcurl.o):hfile_libcurl.c:function libcurl_exit: error: undefined reference to 'curl_global_cleanup'
/tarafs/biobank/data/modules/.local/easybuild/software/HTSlib/1.9-foss-2018b/lib/libhts.a(hfile_s3.o):hfile_s3.c:function auth_header_callback: error: undefined reference to 'EVP_sha1'
/tarafs/biobank/data/modules/.local/easybuild/software/HTSlib/1.9-foss-2018b/lib/libhts.a(hfile_s3.o):hfile_s3.c:function auth_header_callback: error: undefined reference to 'HMAC'
collect2: error: ld returned 1 exit status
make: *** [bin/shapeit4] Error 1
```
It can be solved by adding a missing libs `-lcurl -lssl -lcrypto` like these
```
#DYNAMIC LIBRARIES
DYN_LIBS=-lz -lbz2 -lm -lpthread -llzma -lcurl -lssl -lcrypto
```
So now build process was successful and compatible with this following easyconfig for furthur pull request over easybuild community together.
[sinonkt/easybuild-easyconfigs#shapeit4](https://github.com/sinonkt/easybuild-easyconfigs/commit/b2b2c736bf763a8aff3e3b0926eda7d0dfbd7a0a)
I'm really new when comes to contribute to open source. please advices me if there is anything i can improve. Thank you in advance. Hope this help! :))