### PR TITLE
check for genetic_map being totally outside the vcf region

### DIFF
--- a/src/containers/variant_map.cpp
+++ b/src/containers/variant_map.cpp
@@ -100,7 +100,7 @@ int variant_map::interpolateCentiMorgan(vector < int > & pos_bp, vector < double
 	double mean_rate = (pos_cM.back() - pos_cM[0]) / (pos_bp.back() - pos_bp[0]);
 
 	//Set up first positions to be mean rate
-	while (vec_pos[i_locus]->bp < pos_bp[0]) {
+	while (i_locus<vec_pos.size() && vec_pos[i_locus]->bp < pos_bp[0]) {
 		base = pos_cM[0];
 		dist = (pos_bp[0] - vec_pos[i_locus]->bp);
 		vec_pos[i_locus]->cm = base - mean_rate * dist;


### PR DESCRIPTION
In some cases the genetic map can totally exclude the specified vcf region causing `i_locus` to exceed the length of `vec_pos`  which results in a segfault.

For example `chr21:5130578-10162681` on hg38 was problematic for me since the map starts at 10326676.