### PR TITLE
Change return type of merge

### DIFF
--- a/src/containers/haplotype_set.h
+++ b/src/containers/haplotype_set.h
@@ -47,7 +47,7 @@ struct IBD2track {
 		return ((ind==rhs.ind) && (rhs.to >= from) && (rhs.from <= to));
 	}
 
-	bool merge (const IBD2track & rhs) {
+	void merge (const IBD2track & rhs) {
 		from = min(from, rhs.from);
 		to = max(to, rhs.to);
 	}


### PR DESCRIPTION
Avoid spurious warnings and more importantly, aggressive compiler optimizations leading to crashes. gcc 9.3 and 10.2 both crashed at odd locations when high optimization levels were enabled and the return type was bool with no return statement. In general, compiler optimizatons are allowed to assume that "undefined behavior" does not occur, but I could not swear on a simple return statement missing going into that category.