### PR TITLE
Minor Fixes

### DIFF
--- a/src/io/genotype_reader2.cpp
+++ b/src/io/genotype_reader2.cpp
@@ -253,7 +253,7 @@ void genotype_reader::readGenotypes2(string funphased, string fphased) {
 				n_geno_mis += mi;
 				n_geno_ips += ph;
 			}
-			if (line_scaf=bcf_sr_get_line(sr, 1)) {
+			if ((line_scaf=bcf_sr_get_line(sr, 1))) {
 				ngt_scaf = bcf_get_genotypes(sr->readers[1].header, line_scaf, &gt_arr_scaf, &ngt_arr_scaf); assert(ngt_scaf == 2 * n_scaf_samples);
 				for(int i = 0 ; i < 2 * n_scaf_samples ; i += 2) {
 					int ind = mappingS2G[DIV2(i)];
@@ -380,7 +380,7 @@ void genotype_reader::readGenotypes3(string funphased, string freference, string
 				a0?calt++:cref++;
 				a1?calt++:cref++;
 			}
-			if (line_scaf=bcf_sr_get_line(sr, 2)) {
+			if ((line_scaf=bcf_sr_get_line(sr, 2))) {
 				ngt_scaf = bcf_get_genotypes(sr->readers[2].header, line_scaf, &gt_arr_scaf, &ngt_arr_scaf); assert(ngt_scaf == 2 * n_scaf_samples);
 				for(int i = 0 ; i < 2 * n_scaf_samples ; i += 2) {
 					int ind = mappingS2G[DIV2(i)];

--- a/src/utils/otools.h
+++ b/src/utils/otools.h
@@ -70,8 +70,8 @@ extern "C" {
 #define MAX_AMB				22
 
 //MACROS
-#define DIV2(v)	(v>>1)
-#define MOD2(v)	(v&1)
+#define DIV2(v)	((v)>>1)
+#define MOD2(v)	((v)&1)
 
 //NAMESPACE
 using namespace std;

--- a/src/utils/string_utils.h
+++ b/src/utils/string_utils.h
@@ -61,7 +61,7 @@ public:
 	template < class T >
 	std::string str(T n, int prec = -1) {
 		std::ostringstream ss( std::stringstream::out );
-		if (prec >= 0) { ss << setiosflags( std::ios::fixed ); ss.precision(prec); }
+		if (prec >= 0) { ss << std::setiosflags( std::ios::fixed ); ss.precision(prec); }
 		ss << n;
 		return ss.str();
 	}
@@ -69,7 +69,7 @@ public:
 	template < class T >
 	std::string str(std::vector < T > & v, int prec = -1) {
 		std::ostringstream ss( std::stringstream::out );
-		if (prec >= 0) { ss << setiosflags( std::ios::fixed ); ss.precision(prec); }
+		if (prec >= 0) { ss << std::setiosflags( std::ios::fixed ); ss.precision(prec); }
 		for (int e = 0 ; e < v.size() ; e ++) ss << (e>0?" ":"") << v[e] ;
 		return ss.str();
 	}


### PR DESCRIPTION
Three commits with minor fixes : 
1) Added parentheses around assignment (=) in if clause to remove warning and show that the assignment is intended.
2) Fixed potentially dangerous macros (expansions can lead to unwanted behaviour because of operator precedence).
3) Fixed missing std:: namespace tags